### PR TITLE
Metrics with dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ msg.payload.fields.metric_name= v;
 return msg;
 ```
 
+#### Single value with dimensions enabled :
+```sh
+var o = msg.payload;
+var v = msg.topic;
+msg.payload = {};
+msg.payload.splunkdims = true;
+msg.payload.fields = {};
+msg.payload.fields._value = o;
+msg.payload.fields.metric_name= v;
+msg.payload.fields.dimension1= "value1";
+return msg;
+```

--- a/http-event-collector/http-event-collector-metric.js
+++ b/http-event-collector/http-event-collector-metric.js
@@ -34,14 +34,6 @@ module.exports = function(RED) {
                 console.log("payload isn't json or has already converted");
             }
         
-            if (myMessage.Splunkdims != null){
-                dims = myMessage.fields.Splunkdims
-            }
-
-            // while (myMessage.fields.hasChildNodes()){
-            //     myMessage.fields.removeChild(myMessage.fields.lastChild);
-            // }
-
             // Build New Structure
             var _TemplateStructure = {
                 time: Date.now(),
@@ -53,7 +45,7 @@ module.exports = function(RED) {
                     _value: myMessage.fields._value,
                 }
             }
-            if (myMessage.fields.Splunkdims != null){
+            if (myMessage.splunkdims != null){
                 _TemplateStructure.fields = Object.assign(myMessage.fields);
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-http-event-collector",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "dependencies": {
     "splunk-logging": "git+https://github.com/splunk/splunk-javascript-logging.git"
   },


### PR DESCRIPTION
A minor improvement to use the dimensions for metrics by using the splunkdims field as a toggle. 
If set, all other fields are merged and used as dimensions within Splunk. 

